### PR TITLE
Bumps version up to 10.8.0.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
   configurator:
     plugin: nil
     source: https://github.com/betaflight/betaflight-configurator.git
-    source-tag: 10.7.2
+    source-tag: 10.8.0
     override-pull: |
       snapcraftctl pull
       # adjust icon path for snap


### PR DESCRIPTION
Latest stable version is 10.8.0. 
https://github.com/betaflight/betaflight-configurator/releases

Anything else I need to do for it to update?